### PR TITLE
Review Raiden Ei website

### DIFF
--- a/script.js
+++ b/script.js
@@ -407,6 +407,16 @@ function setupParticleCanvas() {
     animatedElements.forEach(el => { observer.observe(el); });
 }
 
+function prepareScrollAnimationElements() {
+    const animatedElements = document.querySelectorAll('.animate-on-scroll');
+    const slideUpTargets = '.profile-header, .bio, .social-icons, footer, .tweet-embed-container';
+    animatedElements.forEach(el => {
+        if (el.matches(slideUpTargets)) {
+            el.classList.add('slide-up');
+        }
+    });
+}
+
 
     function summonYae(){
       document.addEventListener("click", (e) => {
@@ -807,6 +817,8 @@ function startBirthdayCelebration() {
 
 
    function initializePage() {
+    // Ensure initial offset classes are applied before any preloader/observer logic.
+    prepareScrollAnimationElements();
     handleIntroOverlay();
 
    connectLanyard();


### PR DESCRIPTION
Adjust scroll-triggered animations to play visibly after the preloader finishes.

Previously, animations for elements like the bio and footer would complete while the preloader was still active, making them appear static on page load. This change ensures these elements animate visibly *after* the preloader disappears, providing the intended visual effect. The `slide-up` initial state is now applied immediately, and the `is-visible` class (triggering the animation) is added only after the preloader is gone.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-fc10e3d7-519e-444a-881e-b5dbbd880b49) · [Cursor](https://cursor.com/background-agent?bcId=bc-fc10e3d7-519e-444a-881e-b5dbbd880b49)